### PR TITLE
Feature/tminipro

### DIFF
--- a/sensor/Dockerfile
+++ b/sensor/Dockerfile
@@ -1,7 +1,7 @@
 FROM eduartrobotik/eduart-ros-base:jazzy-1.0.1
 
-ENV ROS_DISTRO jazzy
-ENV USER user
+ENV ROS_DISTRO=jazzy
+ENV USER=user
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install laser filters
@@ -20,6 +20,7 @@ USER $USER
 
 # set up ros workspace
 RUN mkdir -p /home/$USER/ros/src/
+RUN mkdir -p /home/$USER/driver/
 
 # rplidar
 RUN cd /home/$USER/ros/src/ \
@@ -49,6 +50,24 @@ RUN cd /home/$USER/ros/src/ \
 # leuze lidar
 RUN cd /home/$USER/ros/src/ \
     && git clone https://github.com/thesensorpeople/leuze_rsl_ros2_drivers.git \
+    && cd .. \
+    && source /opt/ros/$ROS_DISTRO/setup.bash \
+    && source /home/$USER/.bashrc \
+    && colcon build --symlink-install --event-handlers console_direct+ --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+# ydlidar sdk for t-mini pro
+RUN cd /home/$USER/driver/ \
+    && git clone https://github.com/YDLIDAR/YDLidar-SDK.git \
+    && cd YDLidar-SDK/ \
+    && mkdir build \
+    && cd build/ \
+    && cmake .. \
+    && make -j$(($(nproc)-1)) \
+    && sudo make install
+
+RUN cd /home/$USER/ros/src/ \
+    # && git clone https://github.com/EduArt-Robotik/ydlidar_ros2_driver.git ydlidar_ros2_ws/src/ydlidar_ros2_driver \
+    && git clone --branch humble https://github.com/YDLIDAR/ydlidar_ros2_driver.git ydlidar_ros2_ws/src/ydlidar_ros2_driver \
     && cd .. \
     && source /opt/ros/$ROS_DISTRO/setup.bash \
     && source /home/$USER/.bashrc \

--- a/sensor/Dockerfile
+++ b/sensor/Dockerfile
@@ -57,7 +57,7 @@ RUN cd /home/$USER/ros/src/ \
 
 # ydlidar sdk for t-mini pro
 RUN cd /home/$USER/driver/ \
-    && git clone https://github.com/YDLIDAR/YDLidar-SDK.git \
+    && git clone --branch V1.2.7 https://github.com/YDLIDAR/YDLidar-SDK.git \
     && cd YDLidar-SDK/ \
     && mkdir build \
     && cd build/ \
@@ -66,7 +66,6 @@ RUN cd /home/$USER/driver/ \
     && sudo make install
 
 RUN cd /home/$USER/ros/src/ \
-    # && git clone https://github.com/EduArt-Robotik/ydlidar_ros2_driver.git ydlidar_ros2_ws/src/ydlidar_ros2_driver \
     && git clone --branch humble https://github.com/YDLIDAR/ydlidar_ros2_driver.git ydlidar_ros2_ws/src/ydlidar_ros2_driver \
     && cd .. \
     && source /opt/ros/$ROS_DISTRO/setup.bash \

--- a/sensor/makefile
+++ b/sensor/makefile
@@ -1,4 +1,4 @@
-image_name = sensor:1.0.0
+image_name = sensor:1.0.1
 
 download-sources:
 	git clone --branch ros2 https://github.com/Slamtec/rplidar_ros.git

--- a/sensor/makefile
+++ b/sensor/makefile
@@ -1,11 +1,5 @@
 image_name = sensor:1.0.1
 
-download-sources:
-	git clone --branch ros2 https://github.com/Slamtec/rplidar_ros.git
-	git clone --branch main https://github.com/Slamtec/sllidar_ros2.git
-	git clone --branch master https://github.com/SICKAG/sick_lidar_localization.git
-	git clone https://github.com/thesensorpeople/leuze_rsl_ros2_drivers.git
-
 build-multiarch-and-push:
 	docker buildx build --platform linux/amd64,linux/arm64/v8 -t eduartrobotik/$(image_name) --push .
 

--- a/sensor/tminipro/README.md
+++ b/sensor/tminipro/README.md
@@ -1,0 +1,16 @@
+## Install UDEV Rules
+
+First, the udev rules must be installed. This is required for access to the Tmini-pro device. Navigate into the `tminipro` folder and install rules by:
+
+```bash
+cd ~/edu_docker/sensor/tminipro
+sudo make install-udev-rules
+```
+
+Now plugin the RPLidar device. After the device is plugged it will be listed in device. Please check by:
+
+```bash
+ls /dev
+```
+
+There **tminipro** should be listed.

--- a/sensor/tminipro/docker-compose.yaml
+++ b/sensor/tminipro/docker-compose.yaml
@@ -16,6 +16,6 @@ services:
             - '/dev:/dev'
         group_add:
             - dialout
-        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch ydlidar_launch.py'
+        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch ydlidar_launch.py params_file:="./TminiPro.yaml"'
         volumes:
             - './launch_content:/home/user/ros/launch_content:ro'

--- a/sensor/tminipro/docker-compose.yaml
+++ b/sensor/tminipro/docker-compose.yaml
@@ -16,6 +16,6 @@ services:
             - '/dev:/dev'
         group_add:
             - dialout
-        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch ydlidar_launch.py params_file:="./TminiPro.yaml"'
+        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch ydlidar_launch.py'
         volumes:
             - './launch_content:/home/user/ros/launch_content:ro'

--- a/sensor/tminipro/docker-compose.yaml
+++ b/sensor/tminipro/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+    tminipro:
+        image: eduartrobotik/sensor:1.0.1
+        container_name: eduart-sensor-tminipro-1.0.0
+        user: root
+        restart: always
+        privileged: true
+        ipc: host
+        pid: host
+        mem_limit: 300mb
+        environment:
+            - EDU_ROBOT_NAMESPACE=${EDU_ROBOT_NAMESPACE}
+            - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
+        network_mode: "host"
+        devices:
+            - '/dev:/dev'
+        group_add:
+            - dialout
+        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch ydlidar_launch.py'
+        volumes:
+            - './launch_content:/home/user/ros/launch_content:ro'

--- a/sensor/tminipro/launch_content/TminiPro.yaml
+++ b/sensor/tminipro/launch_content/TminiPro.yaml
@@ -1,6 +1,6 @@
 ydlidar_ros2_driver_node:
   ros__parameters:
-    port: /dev/tminipro
+    port: /dev/ttyUSB0
     frame_id: laser_frame
     ignore_array: ""
     baudrate: 230400

--- a/sensor/tminipro/launch_content/TminiPro.yaml
+++ b/sensor/tminipro/launch_content/TminiPro.yaml
@@ -1,0 +1,24 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/tminipro
+    frame_id: laser_frame
+    ignore_array: ""
+    baudrate: 230400
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 4
+    intensity_bit: 8
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: true
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 12.0
+    range_min: 0.03
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/sensor/tminipro/launch_content/TminiPro.yaml
+++ b/sensor/tminipro/launch_content/TminiPro.yaml
@@ -1,4 +1,4 @@
-ydlidar_ros2_driver_node:
+/**:
   ros__parameters:
     port: /dev/ttyUSB0
     frame_id: laser_frame

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -18,7 +18,7 @@ from launch import LaunchDescription
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, EnvironmentVariable
 from launch.actions import LogInfo
 
 import lifecycle_msgs.msg
@@ -26,27 +26,37 @@ import os
 
 
 def generate_launch_description():
+    robot_namespace = EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard")
     share_dir = get_package_share_directory('ydlidar_ros2_driver')
     parameter_file = LaunchConfiguration('params_file')
     node_name = 'ydlidar_ros2_driver_node'
 
     params_declare = DeclareLaunchArgument('params_file',
                                            default_value=os.path.join(
-                                               share_dir, 'params', 'TminiPro.yaml'),
+                                               share_dir, 'params', 'TminiPro.yaml'),       # TODO: Uses "original" param file, not the modified one with the different port and frame_id
                                            description='FPath to the ROS2 parameters file to use.')
 
     driver_node = LifecycleNode(package='ydlidar_ros2_driver',
-                                executable='ydlidar_ros2_driver_node',
-                                name='ydlidar_ros2_driver_node',
+                                executable=node_name,
+                                name=node_name,
                                 output='screen',
                                 emulate_tty=True,
-                                parameters=[parameter_file],
+                                parameters=[parameter_file,
+                                            # {"port": "/dev/tminipro"},        # Symlink doesn't work, uses default instead (/dev/ttyUSB0) 
+                                            {"frame_id": PathJoinSubstitution([robot_namespace, 'laser'])}
+                                            ],
                                 namespace='/',
+                                remappings=[
+                                    ('/scan', PathJoinSubstitution([robot_namespace, 'scan'])),
+                                    ('/point_cloud', PathJoinSubstitution([robot_namespace, 'point_cloud']))
+                                ]
                                 )
     tf2_node = Node(package='tf2_ros',
                     executable='static_transform_publisher',
                     name='static_tf_pub_laser',
-                    arguments=['0', '0', '0.02','0', '0', '0', '1','base_link','laser_frame'],
+                    arguments=['0.11', '0.0', '0.125','3.141592654', '0.0', '0.0', # TODO: Values only copied from rplidar - must be checked!
+                               PathJoinSubstitution([robot_namespace, 'base_link']),
+                               PathJoinSubstitution([robot_namespace, 'laser'])], 
                     )
 
     return LaunchDescription([

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -1,16 +1,4 @@
 #!/usr/bin/python3
-# Copyright 2020, EAIBOT
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -26,14 +14,16 @@ import os
 
 
 def generate_launch_description():
-    robot_namespace = EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard")
+    edu_robot_namespace = LaunchConfiguration('edu_robot_namespace')
+    edu_robot_namespace_arg = DeclareLaunchArgument('edu_robot_namespace', default_value=os.getenv('EDU_ROBOT_NAMESPACE', 'eduard'))
+
     share_dir = get_package_share_directory('ydlidar_ros2_driver')
     parameter_file = LaunchConfiguration('params_file')
     node_name = 'ydlidar_ros2_driver_node'
 
     params_declare = DeclareLaunchArgument('params_file',
                                            default_value=os.path.join(
-                                               share_dir, 'params', 'TminiPro.yaml'),       # TODO: Uses "original" param file, not the modified one with the different port and frame_id
+                                               share_dir, 'params', 'TminiPro.yaml'),
                                            description='FPath to the ROS2 parameters file to use.')
 
     driver_node = LifecycleNode(package='ydlidar_ros2_driver',
@@ -43,23 +33,24 @@ def generate_launch_description():
                                 emulate_tty=True,
                                 parameters=[parameter_file,
                                             # {"port": "/dev/tminipro"},        # Symlink doesn't work, uses default instead (/dev/ttyUSB0) 
-                                            {"frame_id": PathJoinSubstitution([robot_namespace, 'laser'])}
+                                            {"frame_id": PathJoinSubstitution([edu_robot_namespace, 'laser'])}
                                             ],
                                 namespace='/',
                                 remappings=[
-                                    ('/scan', PathJoinSubstitution([robot_namespace, 'scan'])),
-                                    ('/point_cloud', PathJoinSubstitution([robot_namespace, 'point_cloud']))
+                                    ('/scan', PathJoinSubstitution([edu_robot_namespace, 'scan'])),
+                                    ('/point_cloud', PathJoinSubstitution([edu_robot_namespace, 'point_cloud']))
                                 ]
                                 )
     tf2_node = Node(package='tf2_ros',
                     executable='static_transform_publisher',
                     name='static_tf_pub_laser',
                     arguments=['0.11', '0.0', '0.125','3.141592654', '0.0', '0.0', # TODO: Values only copied from rplidar - must be checked!
-                               PathJoinSubstitution([robot_namespace, 'base_link']),
-                               PathJoinSubstitution([robot_namespace, 'laser'])], 
+                               PathJoinSubstitution([edu_robot_namespace, 'base_link']),
+                               PathJoinSubstitution([edu_robot_namespace, 'laser'])], 
                     )
 
     return LaunchDescription([
+        edu_robot_namespace_arg,
         params_declare,
         driver_node,
         tf2_node,

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -23,7 +23,7 @@ def generate_launch_description():
 
     params_declare = DeclareLaunchArgument('params_file',
                                            default_value=os.path.join(
-                                               share_dir, 'params', 'TminiPro.yaml'),
+                                               './', 'TminiPro.yaml'),
                                            description='FPath to the ROS2 parameters file to use.')
 
     driver_node = LifecycleNode(package='ydlidar_ros2_driver',

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -22,7 +22,8 @@ def generate_launch_description():
         description='Filepath to the ROS2 parameters file to use.'
     )
 
-    driver_node = LifecycleNode(package='ydlidar_ros2_driver',
+    driver_node = LifecycleNode(
+        package='ydlidar_ros2_driver',
         executable=node_name,
         name=node_name,
         output='screen',

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -35,11 +35,7 @@ def generate_launch_description():
                                             # {"port": "/dev/tminipro"},        # Symlink doesn't work, uses default instead (/dev/ttyUSB0) 
                                             {"frame_id": PathJoinSubstitution([edu_robot_namespace, 'laser'])}
                                             ],
-                                namespace='/',
-                                remappings=[
-                                    ('/scan', PathJoinSubstitution([edu_robot_namespace, 'scan'])),
-                                    ('/point_cloud', PathJoinSubstitution([edu_robot_namespace, 'point_cloud']))
-                                ]
+                                namespace=edu_robot_namespace
                                 )
     tf2_node = Node(package='tf2_ros',
                     executable='static_transform_publisher',

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python3
 
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, EnvironmentVariable
-from launch.actions import LogInfo
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
-import lifecycle_msgs.msg
 import os
 
 
@@ -17,37 +13,40 @@ def generate_launch_description():
     edu_robot_namespace = LaunchConfiguration('edu_robot_namespace')
     edu_robot_namespace_arg = DeclareLaunchArgument('edu_robot_namespace', default_value=os.getenv('EDU_ROBOT_NAMESPACE', 'eduard'))
 
-    share_dir = get_package_share_directory('ydlidar_ros2_driver')
     parameter_file = LaunchConfiguration('params_file')
     node_name = 'ydlidar_ros2_driver_node'
 
-    params_declare = DeclareLaunchArgument('params_file',
-                                           default_value=os.path.join(
-                                               './', 'TminiPro.yaml'),
-                                           description='FPath to the ROS2 parameters file to use.')
+    params_declare = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join('./', 'TminiPro.yaml'),
+        description='Filepath to the ROS2 parameters file to use.'
+    )
 
     driver_node = LifecycleNode(package='ydlidar_ros2_driver',
-                                executable=node_name,
-                                name=node_name,
-                                output='screen',
-                                emulate_tty=True,
-                                parameters=[parameter_file,
-                                            # {"port": "/dev/tminipro"},        # Symlink doesn't work, uses default instead (/dev/ttyUSB0) 
-                                            {"frame_id": PathJoinSubstitution([edu_robot_namespace, 'laser'])}
-                                            ],
-                                namespace=edu_robot_namespace
-                                )
-    tf2_node = Node(package='tf2_ros',
-                    executable='static_transform_publisher',
-                    name='static_tf_pub_laser',
-                    arguments=['0.11', '0.0', '0.125','3.141592654', '0.0', '0.0', # TODO: Values only copied from rplidar - must be checked!
-                               PathJoinSubstitution([edu_robot_namespace, 'base_link']),
-                               PathJoinSubstitution([edu_robot_namespace, 'laser'])], 
-                    )
+        executable=node_name,
+        name=node_name,
+        output='screen',
+        emulate_tty=True,
+        parameters=[
+            parameter_file,
+            # {"port": "/dev/tminipro"},        # Symlink doesn't work, uses default instead (/dev/ttyUSB0) 
+            {"frame_id": PathJoinSubstitution([edu_robot_namespace, 'laser'])}
+        ],
+        namespace=edu_robot_namespace
+    )
+    tf2_node = Node(
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        name='static_tf_pub_laser',
+        arguments=[
+            '0.11', '0.0', '0.125','3.141592654', '0.0', '0.0', # TODO: Values only copied from rplidar - must be checked!
+            PathJoinSubstitution([edu_robot_namespace, 'base_link']),
+            PathJoinSubstitution([edu_robot_namespace, 'laser'])]
+    )
 
     return LaunchDescription([
         edu_robot_namespace_arg,
         params_declare,
         driver_node,
-        tf2_node,
+        tf2_node
     ])

--- a/sensor/tminipro/launch_content/ydlidar_launch.py
+++ b/sensor/tminipro/launch_content/ydlidar_launch.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+# Copyright 2020, EAIBOT
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch_ros.actions import LifecycleNode
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.actions import LogInfo
+
+import lifecycle_msgs.msg
+import os
+
+
+def generate_launch_description():
+    share_dir = get_package_share_directory('ydlidar_ros2_driver')
+    parameter_file = LaunchConfiguration('params_file')
+    node_name = 'ydlidar_ros2_driver_node'
+
+    params_declare = DeclareLaunchArgument('params_file',
+                                           default_value=os.path.join(
+                                               share_dir, 'params', 'TminiPro.yaml'),
+                                           description='FPath to the ROS2 parameters file to use.')
+
+    driver_node = LifecycleNode(package='ydlidar_ros2_driver',
+                                executable='ydlidar_ros2_driver_node',
+                                name='ydlidar_ros2_driver_node',
+                                output='screen',
+                                emulate_tty=True,
+                                parameters=[parameter_file],
+                                namespace='/',
+                                )
+    tf2_node = Node(package='tf2_ros',
+                    executable='static_transform_publisher',
+                    name='static_tf_pub_laser',
+                    arguments=['0', '0', '0.02','0', '0', '0', '1','base_link','laser_frame'],
+                    )
+
+    return LaunchDescription([
+        params_declare,
+        driver_node,
+        tf2_node,
+    ])

--- a/sensor/tminipro/makefile
+++ b/sensor/tminipro/makefile
@@ -1,0 +1,9 @@
+install-udev-rules:
+	sudo cp rplidar.rules /etc/udev/rules.d
+	sudo service udev reload
+	sudo service udev restart
+
+remove-udev-rules:
+	sudo rm /etc/udev/rules.d/rplidar.rules
+	sudo service udev reload
+	sudo service udev restart

--- a/sensor/tminipro/tminipro.rules
+++ b/sensor/tminipro/tminipro.rules
@@ -1,0 +1,4 @@
+# set the udev rule , make the device_port be fixed by t-mini pro
+#
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE:="0777", SYMLINK+="tminipro"
+


### PR DESCRIPTION
Adds support for the [YDLidar T-mini Pro](https://www.ydlidar.com/products/view/22.html)

- new subfolder for T-mini Pro
- Adds YDLidar SDK and ROS2 driver to docker image
- fixes some warnings about obsolete notations
- removes unused "download sources" from makefile