### PR TITLE
RPLidar: try to find correct usb port.

### DIFF
--- a/sensor/rplidar/iot2050/docker-compose.yaml
+++ b/sensor/rplidar/iot2050/docker-compose.yaml
@@ -18,6 +18,6 @@ services:
             - '/dev:/dev'
         group_add:
             - dialout
-        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch rplidar.launch.py'
+        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch rplidar.launch.py serial_port:=/dev/ttyUSB0 & ros2 launch rplidar.launch.py serial_port:=/dev/ttyUSB1'
         volumes:
             - './launch_content:/home/user/ros/launch_content:r'

--- a/sensor/rplidar/iot2050/launch_content/rplidar.launch.py
+++ b/sensor/rplidar/iot2050/launch_content/rplidar.launch.py
@@ -12,6 +12,9 @@ def generate_launch_description():
     edu_robot_namespace = LaunchConfiguration('edu_robot_namespace')
     edu_robot_namespace_arg = DeclareLaunchArgument('edu_robot_namespace', default_value=os.getenv('EDU_ROBOT_NAMESPACE', 'eduard'))
 
+    serial_port = LaunchConfiguration('serial_port')
+    serial_port_arg = DeclareLaunchArgument('serial_port', '/dev/ttyUSB0')
+
     parameter_file = PathJoinSubstitution(["./", "laser_angle_filter.yaml",])
 
     rplidar_node = IncludeLaunchDescription(
@@ -23,7 +26,7 @@ def generate_launch_description():
         ])
       ]),
       launch_arguments={
-        'serial_port' : '/dev/ttyUSB0', # actually it should be /dev/rplidar, but then a error code will be rise by the driver...
+        'serial_port' : serial_port, # actually it should be /dev/rplidar, but then a error code will be rise by the driver...
         'frame_id' : PathJoinSubstitution([edu_robot_namespace, 'laser'])
         # 'serial_baudrate' : '115200'
       }.items()


### PR DESCRIPTION
Quick fix that starts rplidar nodes two times, once with `ttyUSB0` and once with `ttyUSB1`.
One rplidar_node will die, the other one runs normally.

Is done because rplidar A1 uses a chip that is also used in some HW-revisions of the IOT. This leads to the issue that it is unclear weather USB0 or USB1 is the Lidar. 


